### PR TITLE
Allow progressive pricing

### DIFF
--- a/contracts/LeftGalleryController.sol
+++ b/contracts/LeftGalleryController.sol
@@ -77,7 +77,6 @@ contract LeftGalleryController is Ownable {
         uint256 printed;
         uint256 price;
         uint256 priceMultiplier;
-        uint256 previousPrice;
         address payable artist;
     }
 
@@ -221,12 +220,11 @@ contract LeftGalleryController is Ownable {
         );
     }
 
-    function nextPrice(uint256 workId) public view returns (uint256) {
-        require(works[workId].exists, "WORK_DOES_NOT_EXIST");
+    function nextPrice(uint256 workId) internal view returns (uint256) {
         if (works[workId].printed == 0) {
             return works[workId].price;
         }
-        return works[workId].previousPrice.mul(works[workId].priceMultiplier).div(100);
+        return works[workId].price.mul(works[workId].priceMultiplier).div(100);
     }
 
     function buy(address recipient, uint256 workId)
@@ -242,12 +240,13 @@ contract LeftGalleryController is Ownable {
 
         require(msg.value >= currentPrice, "DID_NOT_SEND_PRICE");
 
-        works[workId].previousPrice = currentPrice;
+        
         require(
             works[workId].editions - works[workId].AP > works[workId].printed,
             "EDITIONS_EXCEEDED"
         );
         
+        works[workId].price = currentPrice;
         uint256 editionId = works[workId].printed.add(1);
         works[workId].printed = editionId;
 

--- a/contracts/LeftGalleryController.sol
+++ b/contracts/LeftGalleryController.sol
@@ -94,7 +94,7 @@ contract LeftGalleryController is Ownable {
         bool _paused
     ) public onlyOwner {
         require(editions < MAX_EDITIONS, "MAX_EDITIONS_EXCEEDED");
-
+        require(AP < editions, "WORK_AP_EXCEEDS_EDITION");
         latestWorkId += 1;
 
         works[latestWorkId].exists = true;
@@ -156,6 +156,24 @@ contract LeftGalleryController is Ownable {
     {
         require(works[workId].exists, "WORK_DOES_NOT_EXIST");
         works[workId].price = _price;
+        emit updatedWork(
+            workId,
+            works[workId].artist,
+            works[workId].editions,
+            works[workId].AP,
+            works[workId].price,
+            works[workId].adminSplit,
+            works[workId].paused
+        );
+    }
+
+    function updateArtworkAP(uint256 workId, uint256 _AP)
+        public
+        onlyOwner
+    {
+        require(works[workId].exists, "WORK_DOES_NOT_EXIST");
+        require(_AP < works[workId].editions, "WORK_AP_EXCEEDS_EDITION");
+        works[workId].AP = _AP;
         emit updatedWork(
             workId,
             works[workId].artist,

--- a/contracts/LeftGalleryController.sol
+++ b/contracts/LeftGalleryController.sol
@@ -88,7 +88,7 @@ contract LeftGalleryController is Ownable {
     function addArtwork(
         address payable artist,
         uint256 editions,
-        uint256 AP
+        uint256 AP,
         uint256 price,
         uint256 adminSplit,
         bool _paused

--- a/contracts/LeftGalleryController.sol
+++ b/contracts/LeftGalleryController.sol
@@ -31,6 +31,7 @@ contract LeftGalleryController is Ownable {
         address payable artist,
         uint256 editions,
         uint256 price,
+        uint256 adminSplit,
         bool paused
     );
     event updatedWork(
@@ -38,6 +39,7 @@ contract LeftGalleryController is Ownable {
         address payable artist,
         uint256 editions,
         uint256 price,
+        uint256 adminSplit,
         bool paused
     );
     event editionBought(
@@ -59,13 +61,12 @@ contract LeftGalleryController is Ownable {
     struct Work {
         bool exists;
         bool paused;
+        uint256 adminSplit;
         uint256 editions;
         uint256 printed;
         uint256 price;
         address payable artist;
     }
-
-    uint256 public adminSplit = 15;
 
     address payable public adminWallet;
     bool public paused;
@@ -85,6 +86,7 @@ contract LeftGalleryController is Ownable {
         address payable artist,
         uint256 editions,
         uint256 price,
+        uint256 adminSplit,
         bool _paused
     ) public onlyOwner {
         require(editions < MAX_EDITIONS, "MAX_EDITIONS_EXCEEDED");
@@ -95,8 +97,9 @@ contract LeftGalleryController is Ownable {
         works[latestWorkId].editions = editions;
         works[latestWorkId].price = price;
         works[latestWorkId].artist = artist;
+        works[latestWorkId].adminSplit = adminSplit;
         works[latestWorkId].paused = _paused;
-        emit newWork(latestWorkId, artist, editions, price, _paused);
+        emit newWork(latestWorkId, artist, editions, price, adminSplit, _paused);
     }
 
     function updateArtworkPaused(uint256 workId, bool _paused)
@@ -110,6 +113,7 @@ contract LeftGalleryController is Ownable {
             works[workId].artist,
             works[workId].editions,
             works[workId].price,
+            works[workId].adminSplit,
             works[workId].paused
         );
     }
@@ -126,6 +130,7 @@ contract LeftGalleryController is Ownable {
             works[workId].artist,
             works[workId].editions,
             works[workId].price,
+            works[workId].adminSplit,
             works[workId].paused
         );
     }
@@ -141,6 +146,7 @@ contract LeftGalleryController is Ownable {
             works[workId].artist,
             works[workId].editions,
             works[workId].price,
+            works[workId].adminSplit,
             works[workId].paused
         );
     }
@@ -156,6 +162,7 @@ contract LeftGalleryController is Ownable {
             works[workId].artist,
             works[workId].editions,
             works[workId].price,
+            works[workId].adminSplit,
             works[workId].paused
         );
     }
@@ -181,7 +188,7 @@ contract LeftGalleryController is Ownable {
 
         leftGallery.mint(recipient, tokenId);
 
-        uint256 adminReceives = msg.value.mul(adminSplit).div(100);
+        uint256 adminReceives = msg.value.mul(works[workId].adminSplit).div(100);
         uint256 artistReceives = msg.value.sub(adminReceives);
 
         adminWallet.transfer(adminReceives);
@@ -198,9 +205,10 @@ contract LeftGalleryController is Ownable {
         );
     }
 
-    function updateAdminSplit(uint256 _adminSplit) public onlyOwner {
-        require(_adminSplit <= 100, "SPLIT_MUST_BE_LTE_100");
-        adminSplit = _adminSplit;
+    function updateAdminSplit(uint256 workId, uint256 adminSplit) public onlyOwner {
+        require(adminSplit <= 100, "SPLIT_MUST_BE_LTE_100");
+        require(works[workId].exists, "WORK_DOES_NOT_EXIST");
+        works[workId].adminSplit = adminSplit;
     }
 
     function updateAdminWallet(address payable _adminWallet) public onlyOwner {

--- a/contracts/LeftGalleryController.sol
+++ b/contracts/LeftGalleryController.sol
@@ -227,6 +227,15 @@ contract LeftGalleryController is Ownable {
         require(adminSplit <= 100, "SPLIT_MUST_BE_LTE_100");
         require(works[workId].exists, "WORK_DOES_NOT_EXIST");
         works[workId].adminSplit = adminSplit;
+         emit updatedWork(
+            workId,
+            works[workId].artist,
+            works[workId].editions,
+            works[workId].AP,
+            works[workId].price,
+            works[workId].adminSplit,
+            works[workId].paused
+        );
     }
 
     function updateAdminWallet(address payable _adminWallet) public onlyOwner {

--- a/contracts/LeftGalleryController.sol
+++ b/contracts/LeftGalleryController.sol
@@ -222,9 +222,11 @@ contract LeftGalleryController is Ownable {
     }
 
     function nextPrice(uint256 workId) public view returns (uint256) {
-        return works[workId].printed == 0
-            ? works[workId].price
-            : works[workId].previousPrice.mul(works[workId].priceMultiplier.div(100));
+        require(works[workId].exists, "WORK_DOES_NOT_EXIST");
+        if (works[workId].printed == 0) {
+            return works[workId].price;
+        }
+        return works[workId].previousPrice.mul(works[workId].priceMultiplier).div(100);
     }
 
     function buy(address recipient, uint256 workId)

--- a/contracts/LeftGalleryController.sol
+++ b/contracts/LeftGalleryController.sol
@@ -30,6 +30,7 @@ contract LeftGalleryController is Ownable {
         uint256 workId,
         address payable artist,
         uint256 editions,
+        uint256 AP,
         uint256 price,
         uint256 adminSplit,
         bool paused
@@ -38,6 +39,7 @@ contract LeftGalleryController is Ownable {
         uint256 workId,
         address payable artist,
         uint256 editions,
+        uint256 AP,
         uint256 price,
         uint256 adminSplit,
         bool paused
@@ -63,6 +65,7 @@ contract LeftGalleryController is Ownable {
         bool paused;
         uint256 adminSplit;
         uint256 editions;
+        uint256 AP;
         uint256 printed;
         uint256 price;
         address payable artist;
@@ -85,6 +88,7 @@ contract LeftGalleryController is Ownable {
     function addArtwork(
         address payable artist,
         uint256 editions,
+        uint256 AP
         uint256 price,
         uint256 adminSplit,
         bool _paused
@@ -95,11 +99,20 @@ contract LeftGalleryController is Ownable {
 
         works[latestWorkId].exists = true;
         works[latestWorkId].editions = editions;
+        works[latestWorkId].AP = AP;
         works[latestWorkId].price = price;
         works[latestWorkId].artist = artist;
         works[latestWorkId].adminSplit = adminSplit;
         works[latestWorkId].paused = _paused;
-        emit newWork(latestWorkId, artist, editions, price, adminSplit, _paused);
+        emit newWork(
+            latestWorkId,
+            artist,
+            editions,
+            AP,
+            price,
+            adminSplit,
+            _paused
+        );
     }
 
     function updateArtworkPaused(uint256 workId, bool _paused)
@@ -112,6 +125,7 @@ contract LeftGalleryController is Ownable {
             workId,
             works[workId].artist,
             works[workId].editions,
+            works[workId].AP,
             works[workId].price,
             works[workId].adminSplit,
             works[workId].paused
@@ -129,6 +143,7 @@ contract LeftGalleryController is Ownable {
             workId,
             works[workId].artist,
             works[workId].editions,
+            works[workId].AP,
             works[workId].price,
             works[workId].adminSplit,
             works[workId].paused
@@ -145,6 +160,7 @@ contract LeftGalleryController is Ownable {
             workId,
             works[workId].artist,
             works[workId].editions,
+            works[workId].AP,
             works[workId].price,
             works[workId].adminSplit,
             works[workId].paused
@@ -161,6 +177,7 @@ contract LeftGalleryController is Ownable {
             workId,
             works[workId].artist,
             works[workId].editions,
+            works[workId].AP,
             works[workId].price,
             works[workId].adminSplit,
             works[workId].paused
@@ -176,10 +193,11 @@ contract LeftGalleryController is Ownable {
         require(!works[workId].paused, "WORK_NOT_YET_FOR_SALE");
         require(works[workId].exists, "WORK_DOES_NOT_EXIST");
         require(
-            works[workId].editions > works[workId].printed,
+            works[workId].editions + works[workId].AP > works[workId].printed,
             "EDITIONS_EXCEEDED"
         );
         require(msg.value == works[workId].price, "DID_NOT_SEND_PRICE");
+
 
         uint256 editionId = works[workId].printed.add(1);
         works[workId].printed = editionId;

--- a/contracts/LeftGalleryController.sol
+++ b/contracts/LeftGalleryController.sol
@@ -35,8 +35,8 @@ contract LeftGalleryController is Ownable {
 
          // this is a percentage, where 100 means the price remains the same
          // 200 means the price is doubled for each edition
-         // negative values each edition becomes a bit cheaper
-        int256 priceExponent
+
+        uint256 priceMultiplier,
         uint256 adminSplit,
         bool paused
     );
@@ -46,7 +46,7 @@ contract LeftGalleryController is Ownable {
         uint256 editions,
         uint256 AP,
         uint256 price,
-        int256 priceExponent
+        uint256 priceMultiplier,
         uint256 adminSplit,
         bool paused
     );
@@ -74,8 +74,8 @@ contract LeftGalleryController is Ownable {
         uint256 AP;
         uint256 printed;
         uint256 price;
-        int256 priceExponent;
-        int256 previousPrice;
+        uint256 priceMultiplier;
+        uint256 previousPrice;
         address payable artist;
     }
 
@@ -98,7 +98,7 @@ contract LeftGalleryController is Ownable {
         uint256 editions,
         uint256 AP,
         uint256 price,
-        int256 priceExponent,
+        uint256 priceMultiplier,
         uint256 adminSplit,
         bool _paused
     ) public onlyOwner {
@@ -110,7 +110,7 @@ contract LeftGalleryController is Ownable {
         works[latestWorkId].editions = editions;
         works[latestWorkId].AP = AP;
         works[latestWorkId].price = price;
-        works[latestWorkId].priceExponent = priceExponent;
+        works[latestWorkId].priceMultiplier = priceMultiplier;
         works[latestWorkId].artist = artist;
         works[latestWorkId].adminSplit = adminSplit;
         works[latestWorkId].paused = _paused;
@@ -121,7 +121,7 @@ contract LeftGalleryController is Ownable {
             editions,
             AP,
             price,
-            priceExponent,
+            priceMultiplier,
             adminSplit,
             _paused
         );
@@ -139,7 +139,7 @@ contract LeftGalleryController is Ownable {
             works[workId].editions,
             works[workId].AP,
             works[workId].price,
-            works[workId].priceExponent,
+            works[workId].priceMultiplier,
             works[workId].adminSplit,
             works[workId].paused
         );
@@ -158,7 +158,7 @@ contract LeftGalleryController is Ownable {
             works[workId].editions,
             works[workId].AP,
             works[workId].price,
-            works[workId].priceExponent,
+            works[workId].priceMultiplier,
             works[workId].adminSplit,
             works[workId].paused
         );
@@ -176,7 +176,7 @@ contract LeftGalleryController is Ownable {
             works[workId].editions,
             works[workId].AP,
             works[workId].price,
-            works[workId].priceExponent,
+            works[workId].priceMultiplier,
             works[workId].adminSplit,
             works[workId].paused
         );
@@ -195,7 +195,7 @@ contract LeftGalleryController is Ownable {
             works[workId].editions,
             works[workId].AP,
             works[workId].price,
-            works[workId].priceExponent,
+            works[workId].priceMultiplier,
             works[workId].adminSplit,
             works[workId].paused
         );
@@ -213,10 +213,16 @@ contract LeftGalleryController is Ownable {
             works[workId].editions,
             works[workId].AP,
             works[workId].price,
-            works[workId].priceExponent,
+            works[workId].priceMultiplier,
             works[workId].adminSplit,
             works[workId].paused
         );
+    }
+
+    function nextPrice(uint256 workId) public returns (uint256) {
+        return works[workId].printed == 0
+            ? works[workId].price
+            : works[workId].previousPrice.mul(works[workId].priceMultiplier.div(100));
     }
 
     function buy(address recipient, uint256 workId)
@@ -228,10 +234,7 @@ contract LeftGalleryController is Ownable {
         require(!works[workId].paused, "WORK_NOT_YET_FOR_SALE");
         require(works[workId].exists, "WORK_DOES_NOT_EXIST");
 
-
-        uint256 currentPrice = works[workId].printed == 0
-            ? works[workId].price
-            : works[workId].previousPrice.mul(works[workId].priceExponent.div(100));
+        uint256 currentPrice = nextPrice(workId);
 
         require(msg.value >= currentPrice, "DID_NOT_SEND_PRICE");
 
@@ -275,22 +278,22 @@ contract LeftGalleryController is Ownable {
             works[workId].editions,
             works[workId].AP,
             works[workId].price,
-            works[workId].priceExponent,
+            works[workId].priceMultiplier,
             works[workId].adminSplit,
             works[workId].paused
         );
     }
 
-    function updatePriceExponent(uint256 workId, int256 priceExponent) public onlyOwner {
+    function updatePriceExponent(uint256 workId, uint256 priceMultiplier) public onlyOwner {
         require(works[workId].exists, "WORK_DOES_NOT_EXIST");
-        works[workId].priceExponent = priceExponent;
+        works[workId].priceMultiplier = priceMultiplier;
          emit updatedWork(
             workId,
             works[workId].artist,
             works[workId].editions,
             works[workId].AP,
             works[workId].price,
-            works[workId].priceExponent,
+            works[workId].priceMultiplier,
             works[workId].adminSplit,
             works[workId].paused
         );

--- a/contracts/LeftGalleryController.sol
+++ b/contracts/LeftGalleryController.sol
@@ -235,20 +235,16 @@ contract LeftGalleryController is Ownable {
     {
         require(!works[workId].paused, "WORK_NOT_YET_FOR_SALE");
         require(works[workId].exists, "WORK_DOES_NOT_EXIST");
-
-        uint256 currentPrice = nextPrice(workId);
-
-        require(msg.value >= currentPrice, "DID_NOT_SEND_PRICE");
-
-        
+        require(msg.value >= works[workId].price, "DID_NOT_SEND_PRICE");
         require(
             works[workId].editions - works[workId].AP > works[workId].printed,
             "EDITIONS_EXCEEDED"
         );
         
-        works[workId].price = currentPrice;
         uint256 editionId = works[workId].printed.add(1);
         works[workId].printed = editionId;
+        uint256 currentPrice = nextPrice(workId);
+        works[workId].price = currentPrice;
 
         uint256 tokenId = workId.mul(MAX_EDITIONS).add(editionId);
 

--- a/contracts/LeftGalleryController.sol
+++ b/contracts/LeftGalleryController.sol
@@ -40,6 +40,7 @@ contract LeftGalleryController is Ownable {
         uint256 adminSplit,
         bool paused
     );
+
     event updatedWork(
         uint256 workId,
         address payable artist,
@@ -50,6 +51,7 @@ contract LeftGalleryController is Ownable {
         uint256 adminSplit,
         bool paused
     );
+
     event editionBought(
         uint256 workId,
         uint256 editionId,
@@ -219,7 +221,7 @@ contract LeftGalleryController is Ownable {
         );
     }
 
-    function nextPrice(uint256 workId) public returns (uint256) {
+    function nextPrice(uint256 workId) public view returns (uint256) {
         return works[workId].printed == 0
             ? works[workId].price
             : works[workId].previousPrice.mul(works[workId].priceMultiplier.div(100));
@@ -287,7 +289,7 @@ contract LeftGalleryController is Ownable {
     function updatePriceExponent(uint256 workId, uint256 priceMultiplier) public onlyOwner {
         require(works[workId].exists, "WORK_DOES_NOT_EXIST");
         works[workId].priceMultiplier = priceMultiplier;
-         emit updatedWork(
+        emit updatedWork(
             workId,
             works[workId].artist,
             works[workId].editions,

--- a/contracts/LeftGalleryController.sol
+++ b/contracts/LeftGalleryController.sol
@@ -193,7 +193,7 @@ contract LeftGalleryController is Ownable {
         require(!works[workId].paused, "WORK_NOT_YET_FOR_SALE");
         require(works[workId].exists, "WORK_DOES_NOT_EXIST");
         require(
-            works[workId].editions + works[workId].AP > works[workId].printed,
+            works[workId].editions - works[workId].AP > works[workId].printed,
             "EDITIONS_EXCEEDED"
         );
         require(msg.value == works[workId].price, "DID_NOT_SEND_PRICE");

--- a/test/LeftGallery.ts
+++ b/test/LeftGallery.ts
@@ -169,9 +169,7 @@ describe("LeftGallery", () => {
         .to.emit(controller, "newWork")
         .withArgs(1, charly.address, 10, 2, parseEther("1"), 110, 25, false);
 
-      expect(await bobC.nextPrice(1)).to.equal(parseEther("1"));
       const firstWorkBeforeSales = await bobC.works(1);
-      expect(firstWorkBeforeSales.previousPrice).to.equal("0");
       expect(await bobC.buy(bob.address, 1, { value: parseEther("1.0") }))
         .to.emit(controller, "editionBought")
         .withArgs(
@@ -184,9 +182,6 @@ describe("LeftGallery", () => {
           parseEther("0.25")
         );
 
-      const firstWorkAfterSales = await bobC.works(1);
-      expect(firstWorkAfterSales.previousPrice).to.equal(parseEther("1"));
-      expect(await bobC.nextPrice(1)).to.equal(parseEther("1.1"));
       expect(await bobC.buy(bob.address, 1, { value: parseEther("1.1") }))
         .to.emit(controller, "editionBought")
         .withArgs(

--- a/test/LeftGallery.ts
+++ b/test/LeftGallery.ts
@@ -165,13 +165,15 @@ describe("LeftGallery", () => {
           10,
           2,
           parseEther("0.5"),
+          100,
           25,
           false
         )
       )
         .to.emit(controller, "newWork")
-        .withArgs(1, charly.address, 10, 2, parseEther("0.5"), 25, false);
+        .withArgs(1, charly.address, 10, 2, parseEther("0.5"), 100, 25, false);
     });
+
     it("should allow someone to buy the artwork", async function () {
       // Alice adds Charly's artwork
       await controller.addArtwork(
@@ -179,6 +181,7 @@ describe("LeftGallery", () => {
         3, // editions
         1, // APs
         parseEther("0.666"),
+        100, // multiplier
         15,
         false
       );

--- a/test/LeftGallery.ts
+++ b/test/LeftGallery.ts
@@ -157,9 +157,9 @@ describe("LeftGallery", () => {
     it("should increase the price with multiplier", async function () {
       expect(
         await controller.addArtwork(
-          charly.address,
-          10,
-          2,
+          charly.address, // artist
+          10,             // editions
+          2,              // AP
           parseEther("1"),
           110,
           25,
@@ -207,7 +207,7 @@ describe("LeftGallery", () => {
         );
     });
 
-    it("should allow someone to buy the artwork", async function () {
+    it("should allow someone to buy the artwork (but not the AP)", async function () {
       // Alice adds Charly's artwork
       await controller.addArtwork(
         charly.address,

--- a/test/LeftGallery.ts
+++ b/test/LeftGallery.ts
@@ -176,7 +176,7 @@ describe("LeftGallery", () => {
       // Alice adds Charly's artwork
       await controller.addArtwork(
         charly.address,
-        2, // editions
+        3, // editions
         1, // APs
         parseEther("0.666"),
         15,

--- a/test/LeftGallery.ts
+++ b/test/LeftGallery.ts
@@ -163,19 +163,21 @@ describe("LeftGallery", () => {
         await controller.addArtwork(
           charly.address,
           10,
+          2,
           parseEther("0.5"),
           25,
           false
         )
       )
         .to.emit(controller, "newWork")
-        .withArgs(1, charly.address, 10, parseEther("0.5"), 25, false);
+        .withArgs(1, charly.address, 10, 2, parseEther("0.5"), 25, false);
     });
     it("should allow someone to buy the artwork", async function () {
       // Alice adds Charly's artwork
       await controller.addArtwork(
         charly.address,
-        2,
+        2, // editions
+        1, // APs
         parseEther("0.666"),
         15,
         false

--- a/test/LeftGallery.ts
+++ b/test/LeftGallery.ts
@@ -164,11 +164,12 @@ describe("LeftGallery", () => {
           charly.address,
           10,
           parseEther("0.5"),
+          25,
           false
         )
       )
         .to.emit(controller, "newWork")
-        .withArgs(1, charly.address, 10, parseEther("0.5"), false);
+        .withArgs(1, charly.address, 10, parseEther("0.5"), 25, false);
     });
     it("should allow someone to buy the artwork", async function () {
       // Alice adds Charly's artwork
@@ -176,6 +177,7 @@ describe("LeftGallery", () => {
         charly.address,
         2,
         parseEther("0.666"),
+        15,
         false
       );
 


### PR DESCRIPTION
This PR continues https://github.com/left-gallery/contracts/pull/2

This allows an automatic gradual increase or decrease in price. Because Solidity does not have a native `.pow` method I keep the `previousPrice` in state on the work struct, and multiply for each successive edition.

I prefer to use an exponent over a factor because this allows, for example, the following price development.

- edition 1: 0.5 eth
- edition 2: 1.0 eth
- edition 3: 2.0 eth
- edition 4: 4.0 eth

Also I allow the buyer to overpay, which might solve a situation where the rounding errors would make the price a bit unclear.


